### PR TITLE
[XEND-3] Implement pagination on `GET: /rides`

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -10,7 +10,7 @@
   ],
   "reporter": [
     "lcov",
-    "text-summary"
+    "text"
   ],
   "cache": true
 }

--- a/Readme.md
+++ b/Readme.md
@@ -60,13 +60,13 @@ Please implement the following tooling:
 
 ### Implement Pagination
 
-Please implement pagination to retrieve pages of the resource `rides`.
+~~Please implement pagination to retrieve pages of the resource `rides`.~~
 
-1. Create a pull request against `master` with your changes to the `GET /rides` endpoint to support pagination including:
-    1. Code changes
-    2. Tests
-    3. Documentation
-2. Merge the pull request
+1. ~~Create a pull request against `master` with your changes to the `GET /rides` endpoint to support pagination including:~~
+    1. ~~Code changes~~
+    2. ~~Tests~~
+    3. ~~Documentation~~
+2. ~~Merge the pull request~~
 
 ### Refactoring
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -166,26 +166,82 @@
       "get": {
         "operationId": "rides",
         "summary": "Get list of rides",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "keyword",
+            "description": "Keyword for searching in `riderName`, `driverName` or `driverVehicle`",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "Sort for rider, driver and vehicle, **use '-' for descending**",
+            "required": true,
+            "schema": { "type": "string", "enum": [
+              "rider",
+              "-rider",
+              "driver",
+              "-driver",
+              "vehicle",
+              "-vehicle"
+            ] }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Amount of rides per page",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "Page cursor",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of rides",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Ride"
+                  "type": "object",
+                  "required": [
+                    "rides",
+                    "total"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Ride"
+                      }
+                    },
+                    "count": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "currentPage": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "nextPage": {
+                      "type": "integer",
+                      "example": null
+                    },
+                    "prevPage": {
+                      "type": "integer",
+                      "example": null
+                    },
+                    "lastPage": {
+                      "type": "integer",
+                      "example": 1
+                    }
                   }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No ride can be found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NOT_FOUND"
                 }
               }
             }

--- a/src/middlewares/error.test.ts
+++ b/src/middlewares/error.test.ts
@@ -87,34 +87,21 @@ describe('Error middleware', () => {
     });
   });
 
-  // it('without "authorization" header', async () => {
-  //   const expectedResponse = {
-  //     error: "Missing JWT token from the 'Authorization' header",
-  //   };
-  //   mockRequest = {
-  //     headers: {},
-  //   };
-  //   errorMiddleware(
-  //     mockRequest as Request,
-  //     mockResponse as Response,
-  //     nextFunction,
-  //   );
+  it('should send internal server error body with 500 status', async () => {
+    const mockError = 'Non-contructored error';
+    const stubbedConsole = sandbox.stub(console, 'error');
+    errorMiddleware(
+      mockError,
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction,
+    );
 
-  //   expect(mockResponse.json).toBeCalledWith(expectedResponse);
-  // });
-
-  // it('with "authorization" header', async () => {
-  //   mockRequest = {
-  //     headers: {
-  //       authorization: 'Bearer abc',
-  //     },
-  //   };
-  //   errorMiddleware(
-  //     mockRequest as Request,
-  //     mockResponse as Response,
-  //     nextFunction,
-  //   );
-
-  //   expect(nextFunction).toBeCalledTimes(1);
-  // });
+    expect(mockResponse.status).to.have.been.calledWith(500);
+    expect(mockResponse.send).to.have.been.calledWith({
+      error_code: 'SERVER_ERROR',
+      message: 'Unknown error',
+    });
+    expect(stubbedConsole).to.have.been.called;
+  });
 });

--- a/src/middlewares/error.ts
+++ b/src/middlewares/error.ts
@@ -19,7 +19,13 @@ const errorMiddleware = (
       error_code: 'SERVER_ERROR',
       message: 'Unknown error',
     });
-    logger.error(error);
+
+    if (error instanceof Error) {
+      logger.error(error.message);
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
   }
 };
 


### PR DESCRIPTION
### What

This PR is to implement pagination on `GET: /rides`

#### Includes:

1 . `keyword`, `limit`, `page` and `sort` params
2. Fix error not being logged

#### Screenshots

<img width="590" alt="image" src="https://user-images.githubusercontent.com/37780658/169568126-fa5167a5-d1dd-43b4-a027-6fe104229e61.png">

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/37780658/169568167-2f343588-ab4f-405f-ba8f-d5415f72af78.png">
